### PR TITLE
Update densify.desktop with StartupWMClass=densify

### DIFF
--- a/densify.desktop
+++ b/densify.desktop
@@ -10,3 +10,4 @@ Type=Application
 Icon=/opt/Densify/desktop-icon.png
 StartupNotify=true
 Categories=Utility;Application;
+StartupWMClass=densify


### PR DESCRIPTION
hello! 🙂
Gnome dash shows generic icon if desktop file doesn't have StartupWMClass=densify
so if you can merge this its cool 👍